### PR TITLE
Update error pattern

### DIFF
--- a/flycheck-credo.el
+++ b/flycheck-credo.el
@@ -67,10 +67,10 @@ When non-nil, pass the `--strict' flag to credo."
                   (locate-dominating-file buffer-file-name "deps/credo")))
   :working-directory flycheck-credo--working-directory
   :error-patterns
-  ((info line-start (file-name) ":" line ":" column ": " (or "F" "R" "C")  ": " (message) line-end)
-   (info line-start (file-name) ":" line ": " (or "F" "R" "C")  ": " (message) line-end)
-   (warning line-start (file-name) ":" line ":" column ": " (or "D" "W")  ": " (message) line-end)
-   (warning line-start (file-name) ":" line ": " (or "D" "W")  ": " (message) line-end))
+  ((info line-start "stdin:" line ":" column ": " (or "F" "R" "C")  ": " (message) line-end)
+   (info line-start "stdin:" line ": " (or "F" "R" "C")  ": " (message) line-end)
+   (warning line-start "stdin:" line ":" column ": " (or "D" "W")  ": " (message) line-end)
+   (warning line-start "stdin:" line ": " (or "D" "W")  ": " (message) line-end))
   :modes elixir-mode)
 
 ;;;###autoload


### PR DESCRIPTION
Because output says "stdin", not the file name:

```
$ mix credo --strict --format flycheck --read-from-stdin < foo.ex
stdin:34: F: Pipe chain should start with a raw value.

$ mix --version
Erlang/OTP 19 [erts-8.3] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Mix 1.4.2
```