### PR TITLE
Fix for umbrella apps where credo is only installed at top level mix.exs

### DIFF
--- a/flycheck-credo.el
+++ b/flycheck-credo.el
@@ -41,9 +41,9 @@
 (require 'flycheck)
 
 (defun flycheck-credo--working-directory (&rest _ignored)
-  "Find directory with mix.exs."
+  "Find directory with from which we can run credo."
   (and buffer-file-name
-       (locate-dominating-file buffer-file-name "mix.exs")))
+       (locate-dominating-file buffer-file-name "deps/credo")))
 
 (flycheck-def-option-var flycheck-elixir-credo-strict nil elixir-credo
   "Enable strict mode in credo.


### PR DESCRIPTION
I had a problem in my project where we had umbrella apps:

`./mix.exs` - credo installed here
`./apps/x/mix.exs` - no credo
`./apps/y/mix.exs` - no credo here either

I'd get errors in Emacs saying `** (Mix) The task "credo" could not be found` because it was trying to run `mix credo` in `./apps/x/` and not `./`.

This change seems like it'd more reliably find the right directory to run `mix credo` in, and fixes my problem.